### PR TITLE
Replace arrows and "smart" quotes with html entities

### DIFF
--- a/docs/contact.html
+++ b/docs/contact.html
@@ -7,10 +7,10 @@
 <H1>Contact Information</H1>
 
 <CITE>
-“The Silmaril as lantern light<BR>
+&ldquo;The Silmaril as lantern light<BR>
 And banner bright with living flame<BR>
 To gleam thereon by Elbereth<BR>
-Herself was set, who thither came.”
+Herself was set, who thither came.&rdquo;
 </CITE>
 
 <HR>

--- a/docs/emulwindow.html
+++ b/docs/emulwindow.html
@@ -11,7 +11,7 @@
 <P>The emulation window displays the C64 graphics and receives the keyboard
 input.
 
-<P>If the “Show Speed and Drive LED Status” <A
+<P>If the &ldquo;Show Speed and Drive LED Status&rdquo; <A
 HREF="settings.html">setting</A> is enabled, Frodo uses the lower border of
 the C64 display to overlay some information about the emulation speed
 (unless it is running at 100%) and a representation of the activity and
@@ -22,10 +22,10 @@ or Frodo snapshot files onto the emulation window to mount the image in
 drive 8 or 1, or restore the snapshot state, respectively. You can also drop
 folders to mount them in drive 8 in directory mode.
 
-<P>Dropping a .crt cartridge image file onto the window “inserts” the
+<P>Dropping a .crt cartridge image file onto the window &ldquo;inserts&rdquo; the
 cartridge and also resets the C64 to allow the cartridge software to start.
 Finally, you can drop C64 BASIC program files to directly load them into the
-memory of the C64 (enter “RUN” to start a program after loading).
+memory of the C64 (enter &ldquo;RUN&rdquo; to start a program after loading).
 
 </BODY>
 </HTML>

--- a/docs/flavours.html
+++ b/docs/flavours.html
@@ -8,17 +8,17 @@
 
 <HR>
 
-<P>Frodo comes in two “flavours” that allow you to decide between speed and
+<P>Frodo comes in two &ldquo;flavours&rdquo; that allow you to decide between speed and
 accuracy of the emulation.
 
-<H2>The single-cycle emulation “Frodo”</H2>
+<H2>The single-cycle emulation &ldquo;Frodo&rdquo;</H2>
 
 <P><B>Frodo</B> works with a cycle-based emulation model. That means that
 the emulator switches between 6510 and VIC in every emulated ø2 clock phase.
 By doing this, Frodo achieves a very high precision (nearly all graphical
 effects can be emulated), but at the expense of speed.
 
-<H2>The line-based emulation “Frodo Lite”</H2>
+<H2>The line-based emulation &ldquo;Frodo Lite&rdquo;</H2>
 
 <P><B>Frodo Lite</B> is a simplified version of Frodo that is line-based,
 meaning that the activities that happen in parallel during one video line in

--- a/docs/history.html
+++ b/docs/history.html
@@ -7,9 +7,9 @@
 <H1>Revision history</H1>
 
 <CITE>
-“Those days, the Third Age of Middle-earth,<BR>
+&ldquo;Those days, the Third Age of Middle-earth,<BR>
 are now long past, and the shape of all lands<BR>
-has been changed.”
+has been changed.&rdquo;
 </CITE>
 
 <HR>
@@ -258,7 +258,7 @@ emulation and built-in SID emulation
 
 <H3>V4.3</H3>
 <UL>
-<LI>“Frodo SC” renamed to “Frodo”, original “Frodo” renamed to “Frodo Lite”
+<LI>&ldquo;Frodo SC&rdquo; renamed to &ldquo;Frodo&rdquo;, original &ldquo;Frodo&rdquo; renamed to &ldquo;Frodo Lite&rdquo;
 <LI>Ported to SDL2 and GTK 3
 <LI>Removed most platform-specific support, main target is now SDL
 <LI>Unix: settings are now stored in ~/.local/share/cebix/Frodo/config
@@ -279,12 +279,12 @@ instead of ~/.frodorc
  <LI>Added setting for initial window size (ScalingNumerator)
  <LI>Added setting for color palette (Palette)
  <LI>Added setting for SID type
- <LI>Removed “Draw every n-th frame” setting
+ <LI>Removed &ldquo;Draw every n-th frame&rdquo; setting
  <LI>Added menu items for loading/saving snapshot files
  <LI>Added menu item for creating a blank D64 image
- <LI>Added “Eject” and “Next Disk” buttons to the drive paths
+ <LI>Added &ldquo;Eject&rdquo; and &ldquo;Next Disk&rdquo; buttons to the drive paths
  </UL>
-<LI>SAM is now started from the “Tools” menu in the settings window instead
+<LI>SAM is now started from the &ldquo;Tools&rdquo; menu in the settings window instead
 of by pressing F9
 <LI>Enabled drag-and-drop of files and folders onto the emulator window to
 mount disk image files and directories, mount cartridge files, load snapshot
@@ -305,7 +305,7 @@ files, or load BASIC program files
 <LI>Command line option '-c' is now used to specify a different
 configuration file than the default
 <LI>Settings from configuration file can be overridden on command line (for
-example “DrivePath8=/path/to/disk.d64”)
+example &ldquo;DrivePath8=/path/to/disk.d64&rdquo;)
 <LI>Holding down Ctrl while pressing F12 resets the C64 and auto-starts from
 disk drive 8
 <LI>Settings window changes:
@@ -313,11 +313,11 @@ disk drive 8
  <LI>Added ability to map game controller buttons to keys on the C64
      keyboard or the tape PLAY button
  <LI>Added ability to define firmware ROM sets, and switch between them
- <LI>Added option for twin-stick joystick control (for games like “Robotron
-     2084”)
+ <LI>Added option for twin-stick joystick control (for games like &ldquo;Robotron
+     2084&rdquo;)
  <LI>Added option to enable controller rumble effects via the C64 tape drive
-     motor signal (for the game “Aquarius”)
- <LI>Added “Auto-Start Drive 8” button
+     motor signal (for the game &ldquo;Aquarius&rdquo;)
+ <LI>Added &ldquo;Auto-Start Drive 8&rdquo; button
  <LI>Added menu item for opening the included user manual
  <LI>Removed "Display Sprites" and "Enable SID Filters" settings which are
      now always enabled

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -26,7 +26,7 @@ packages) contain an executable that can be started directly.
 <P>You can compile and install Frodo in the usual way:
 
 <P><KBD>$ ./autogen.sh<BR>
-$ make<BR>
+$ make -j<BR>
 $ sudo make install</KBD>
 
 
@@ -43,7 +43,7 @@ software packages.
 <P>Now you can compile and install Frodo:
 
 <P><KBD>% ./autogen.sh<BR>
-% make<BR>
+% make -j<BR>
 % make install</KBD>
 
 
@@ -64,7 +64,7 @@ $ pacman -S mingw-w64-ucrt-x86_64-gtk3</KBD>
 <P>Now you can compile and install Frodo:
 
 <P><KBD>$ ./autogen.sh<BR>
-$ make<BR>
+$ make -j<BR>
 $ make install</KBD>
 
 </BODY>

--- a/docs/keyboard.html
+++ b/docs/keyboard.html
@@ -12,8 +12,8 @@
 individual rows of the keyboard are mapped as follows:
 
 <PRE>
-← 1 2 3 4 5 6 7 8 9 0 + -
-   Q W E R T Y U I O P @ * ↑
+&larr; 1 2 3 4 5 6 7 8 9 0 + -
+   Q W E R T Y U I O P @ * &uarr;
     A S D F G H J K L : ;
      Z X C V B N M , . /
 </PRE>
@@ -32,7 +32,7 @@ the C64 keyboard, or to control functions of the emulator:
  Alt Keys     - C=
  Ctrl Keys    - CTRL
  Caps lock    - SHIFT LOCK
- Arrow keys   - CRSR ↑/↓ and CRSR ←/→
+ Arrow keys   - CRSR &uarr;/&darr; and CRSR &larr;/&rarr;
  F1-F8        - F1-F8
  F10          - Open <A HREF="settings.html">settings window</A>
  F11          - RESTORE
@@ -41,7 +41,7 @@ the C64 keyboard, or to control functions of the emulator:
  Ctrl + F12   - Reset C64 and 1541 and auto-start from drive 1 or 8
  Home         - CLR/HOME
  End          - &pound;
- Page Up      - ↑
+ Page Up      - &uarr;
  Page Down    - =
  Keypad Enter - Toggle fullscreen mode
  Keypad Plus  - Fast-forward
@@ -61,12 +61,12 @@ state of the Num Lock (Num Lock off: port 2, Num Lock on: port 1):
 
 <PRE>
    7    8    9
-    ↖   ↑   ↗
+   &#x2196;    &uarr;    &#x2197;
 
    4    5    6
-    ←  Fire →
+   &larr;  Fire   &rarr;
 
-    ↙   ↓   ↘
+    &#x2199;   &darr;   &#x2198;
    1    2    3
 
    0

--- a/docs/legalmush.html
+++ b/docs/legalmush.html
@@ -8,7 +8,7 @@
 
 <HR>
 
-<P>The “Frodo” Commodore 64 emulator is Copyright &copy; Christian Bauer.
+<P>The &ldquo;Frodo&rdquo; Commodore 64 emulator is Copyright &copy; Christian Bauer.
 
 <P>This program is free software; you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the Free

--- a/docs/sam.html
+++ b/docs/sam.html
@@ -7,14 +7,14 @@
 <H1>SAM</H1>
 
 <CITE>
-“Frodo! Mr. Frodo, my dear!” cried Sam,<BR>
-tears almost blinding him. “It's Sam, I've come!”
+&ldquo;Frodo! Mr. Frodo, my dear!&rdquo; cried Sam,<BR>
+tears almost blinding him. &ldquo;It's Sam, I've come!&rdquo;
 </CITE>
 
 <HR>
 
 <P>Frodo has a built-in machine language monitor that can be activated from
-the “Tools” menu of the <A HREF="settings.html">settings window</A>: SAM
+the &ldquo;Tools&rdquo; menu of the <A HREF="settings.html">settings window</A>: SAM
 (<EM>Simple Assembler and Monitor</EM>). It provides full access to the
 memory and hardware of the emulated C64 and 1541.
 
@@ -22,10 +22,10 @@ memory and hardware of the emulated C64 and 1541.
 represented in hexadecimal. With the command 'h' you can display a list of
 all commands.
 
-<P>SAM has two modes of operation, indicated by the prompt “C64>” or
-“1541>”. You can switch between them with the “64” and “1541” commands. In
-“C64” mode, all commands that access memory or the CPU operate on the
-memory/CPU of the emulated C64. In “1541” mode, they operate on the emulated
+<P>SAM has two modes of operation, indicated by the prompt &ldquo;C64>&rdquo; or
+&ldquo;1541>&rdquo;. You can switch between them with the &ldquo;64&rdquo; and &ldquo;1541&rdquo; commands. In
+&ldquo;C64&rdquo; mode, all commands that access memory or the CPU operate on the
+memory/CPU of the emulated C64. In &ldquo;1541&rdquo; mode, they operate on the emulated
 1541 (this is only useful if the processor-level 1541 emulation is turned
 on).
 
@@ -51,11 +51,11 @@ command stopped):
  a [start]           Assemble
 </PRE>
 
-<P>starts the assembler at the address “start”. SAM always prints the
+<P>starts the assembler at the address &ldquo;start&rdquo;. SAM always prints the
 address where the next instruction will be written to. The syntax of the
 instructions conforms to the standard except for shift/rotate instructions
-in the “accumulator” addressing mode. Those have to be entered without
-operand, e.g. “lsr” instead of “lsr a”. Entering a blank line quits the
+in the &ldquo;accumulator&rdquo; addressing mode. Those have to be entered without
+operand, e.g. &ldquo;lsr&rdquo; instead of &ldquo;lsr a&rdquo;. Entering a blank line quits the
 assembler and returns to the command mode of SAM.
 
 
@@ -63,7 +63,7 @@ assembler and returns to the command mode of SAM.
  b [start] [end]     Binary dump
 </PRE>
 
-<P>displays the memory from “start” to “end” in byte-wise binary
+<P>displays the memory from &ldquo;start&rdquo; to &ldquo;end&rdquo; in byte-wise binary
 representation. With this command, you can view character sets.
 
 
@@ -71,8 +71,8 @@ representation. With this command, you can view character sets.
  c start end dest    Compare memory
 </PRE>
 
-<P>compares the memory in the range from “start” to (and including) “end”
-with the memory at “dest”. The addresses of all different bytes and the
+<P>compares the memory in the range from &ldquo;start&rdquo; to (and including) &ldquo;end&rdquo;
+with the memory at &ldquo;dest&rdquo;. The addresses of all different bytes and the
 total number of differences (in decimal) are printed.
 
 
@@ -80,7 +80,7 @@ total number of differences (in decimal) are printed.
  d [start] [end]     Disassemble
 </PRE>
 
-<P>disassembles the memory from “start” to “end”. Undocumented opcodes are
+<P>disassembles the memory from &ldquo;start&rdquo; to &ldquo;end&rdquo;. Undocumented opcodes are
 marked with a star '*'.
 
 
@@ -96,15 +96,15 @@ marked with a star '*'.
  f start end byte    Fill memory
 </PRE>
 
-<P>fills the memory in the range from “start” to (and including) “end” with
-the value “byte”.
+<P>fills the memory in the range from &ldquo;start&rdquo; to (and including) &ldquo;end&rdquo; with
+the value &ldquo;byte&rdquo;.
 
 
 <PRE>
  i [start] [end]     ASCII/PETSCII dump
 </PRE>
 
-<P>shows the memory from “start” to “end” as ASCII/PETSCII characters.
+<P>shows the memory from &ldquo;start&rdquo; to &ldquo;end&rdquo; as ASCII/PETSCII characters.
 
 
 <PRE>
@@ -136,7 +136,7 @@ effect in 1541 mode. The 8 possible configurations are:
 </PRE>
 
 <P>loads the contents of the specified file into memory starting from
-address “start”. The file name must be enclosed in quotation marks even if
+address &ldquo;start&rdquo;. The file name must be enclosed in quotation marks even if
 it contains no spaces. This command cannot be used to load C64 programs as
 it doesn't respect the embedded load address in the program.
 
@@ -145,7 +145,7 @@ it doesn't respect the embedded load address in the program.
  m [start] [end]     Memory dump
 </PRE>
 
-<P>displays the memory from “start” to “end” as hexadecimal numbers and
+<P>displays the memory from &ldquo;start&rdquo; to &ldquo;end&rdquo; as hexadecimal numbers and
 ASCII/PETSCII characters.
 
 
@@ -153,7 +153,7 @@ ASCII/PETSCII characters.
  n [start] [end]     Screen code dump
 </PRE>
 
-<P>displays the memory from “start” to “end” as characters, interpreting
+<P>displays the memory from &ldquo;start&rdquo; to &ldquo;end&rdquo; as characters, interpreting
 each byte as a screen code of the standard C64 character set.
 
 
@@ -171,7 +171,7 @@ output into the window of SAM again.
  p [start] [end]     Sprite dump
 </PRE>
 
-<P>displays the memory from “start” to “end” in binary representation with
+<P>displays the memory from &ldquo;start&rdquo; to &ldquo;end&rdquo; in binary representation with
 three bytes per line. With this command, you can view sprite data.
 
 
@@ -181,16 +181,16 @@ three bytes per line. With this command, you can view sprite data.
 
 <P>'r' without parameters shows all 6510 (C64) or 6502 (1541) registers and
 flags, and the instruction at the address specified by the program counter.
-For the 6510, “DR” and “PR” are the data direction register and data
-register of the processor port. To modify a register, give its name (“reg”)
-and the new value (“value”) as parameters.
+For the 6510, &ldquo;DR&rdquo; and &ldquo;PR&rdquo; are the data direction register and data
+register of the processor port. To modify a register, give its name (&ldquo;reg&rdquo;)
+and the new value (&ldquo;value&rdquo;) as parameters.
 
 
 <PRE>
  s start end "file"  Save data
 </PRE><P>
 
-<P>writes the memory from “start” to (and including) “end” to the specified
+<P>writes the memory from &ldquo;start&rdquo; to (and including) &ldquo;end&rdquo; to the specified
 file. The file name must be enclosed in quotation marks even if it contains
 no spaces. This command cannot be used to save C64 programs as it doesn't
 save a load address in the file.
@@ -200,7 +200,7 @@ save a load address in the file.
  t start end dest    Transfer memory
 </PRE>
 
-<P>transfers the memory from “start” to (and including) “end” to “dest”.
+<P>transfers the memory from &ldquo;start&rdquo; to (and including) &ldquo;end&rdquo; to &ldquo;dest&rdquo;.
 Source and destination may overlap.
 
 
@@ -243,7 +243,7 @@ Source and destination may overlap.
  : addr {byte}       Modify memory
 </PRE><P>
 
-<P>writes the space-separated values “byte” into memory starting at “addr”.
+<P>writes the space-separated values &ldquo;byte&rdquo; into memory starting at &ldquo;addr&rdquo;.
 
 
 <PRE>

--- a/docs/settings.html
+++ b/docs/settings.html
@@ -18,11 +18,11 @@ by specifying an image file on the <A HREF="commandline.html">command line</A>.
 
 <H2>Drives</H2>
 
-<P>The box <B>“Disk Drive Paths”</B> has four fields, each corresponding to
+<P>The box <B>&ldquo;Disk Drive Paths&rdquo;</B> has four fields, each corresponding to
 one of four emulated Commodore 1541 floppy disk drives with the drive
 numbers 8, 9, 10 and 11 (normally you only need drive 8). For each drive,
-there is a <EM>file selection button</EM>, an <EM>“Eject” button</EM> and a
-<EM>“Next Disk” button</EM>.
+there is a <EM>file selection button</EM>, an <EM>&ldquo;Eject&rdquo; button</EM> and a
+<EM>&ldquo;Next Disk&rdquo; button</EM>.
 
 <P>Frodo offers three different modes for disk drive emulation (see <A
 HREF="files.html">here</A> for details):
@@ -33,11 +33,11 @@ HREF="files.html">here</A> for details):
 emulation. This is the preferred mode with the highest compatibility.
 <LI><EM>Tape/Archive Mode</EM> makes the contents of a .t64 tape image file,
 a LYNX archive file, or a single .p00 program file available to the emulated
-C64 as a “pseudo disk”, which is accessed as if it was a floppy disk. For
-actual tape drive emulation, see the <EM>“Tape Drive Path”</EM> settings,
+C64 as a &ldquo;pseudo disk&rdquo;, which is accessed as if it was a floppy disk. For
+actual tape drive emulation, see the <EM>&ldquo;Tape Drive Path&rdquo;</EM> settings,
 below.
 <LI><EM>Directory Mode</EM> makes the contents of a directory of the host
-file system available to the emulated C64 as a “pseudo disk”.
+file system available to the emulated C64 as a &ldquo;pseudo disk&rdquo;.
 </UL>
 
 <P>The <B>file selection button</B> opens a dialog where you can choose a
@@ -45,18 +45,18 @@ file system available to the emulated C64 as a “pseudo disk”.
 To select a directory for Directory Mode, choose any file within the
 directory that is not of one of those image file types.
 
-<P>Clicking on the <B>“Eject” button</B> unmounts the selected file or
+<P>Clicking on the <B>&ldquo;Eject&rdquo; button</B> unmounts the selected file or
 directory from the respective drive. When full 1541 emulation is enabled,
 the drive will behave like it has no disk in it, otherwise the drive will be
 disconnected entirely.
 
-<P>The <B>“Next Disk” button</B> only works in Disk Image Mode and changes
+<P>The <B>&ldquo;Next Disk&rdquo; button</B> only works in Disk Image Mode and changes
 the mounted .d64/.x64/.g64 disk image file to the next one in a series.
-Frodo tries to be a bit clever about figuring out what that “next disk”
-actually is. If the image files have names ending with patterns like “Disk
-1”/“Disk 2”, “Side A”/“Side B”, “(1)”/“(2)”, etc. it is usually successful.
+Frodo tries to be a bit clever about figuring out what that &ldquo;next disk&rdquo;
+actually is. If the image files have names ending with patterns like &ldquo;Disk
+1&rdquo;/&ldquo;Disk 2&rdquo;, &ldquo;Side A&rdquo;/&ldquo;Side B&rdquo;, &ldquo;(1)&rdquo;/&ldquo;(2)&rdquo;, etc. it is usually successful.
 
-<P>If <B>“Enable Full 1541 Emulation”</B> is turned on, the four emulated
+<P>If <B>&ldquo;Enable Full 1541 Emulation&rdquo;</B> is turned on, the four emulated
 1541s are disabled and replaced by a single 1541 emulation (drive 8) that
 only operates on .d64/.x64/.g64 files, but emulates the entire 1541 hardware
 and is compatible with most fast loaders and some forms of copy protection,
@@ -64,7 +64,7 @@ at the expense of considerably slower disk access. If you have a .d64 with a
 program that doesn't load with the normal emulation (see above), you may
 have better luck with the full 1541 processor emulation instead.
 
-<P>With <B>“Map / ↔ \ in file names”</B> you control whether a '/' in
+<P>With <B>&ldquo;Map / &harr; \ in file names&rdquo;</B> you control whether a '/' in
 C64 filenames will be translated to '\' and vice versa for Directory Mode
 drives. On many systems, the '/' character is used to access subdirectories,
 but since the C64/1541 doesn't support subdirectories, that character is a
@@ -76,43 +76,43 @@ checkbox all '/'s will transparently be translated into '\', so in directory
 listings the '/' will still appear. If you turn off this option, you can
 actually use the '/' to access files in subdirectories from the C64.
 
-<P>In the box <B>“Tape Drive Path”</B> (not available in Frodo Lite) you can
-choose a .tap tape image file to mount in the emulated “Datasette” tape
-drive with drive number 1 The <EM>file selection button</EM> and <EM>“Eject”
+<P>In the box <B>&ldquo;Tape Drive Path&rdquo;</B> (not available in Frodo Lite) you can
+choose a .tap tape image file to mount in the emulated &ldquo;Datasette&rdquo; tape
+drive with drive number 1 The <EM>file selection button</EM> and <EM>&ldquo;Eject&rdquo;
 button</EM> work in the same way as for the disk drives. Note that you
 cannot use .t64 files for the tape drive even though they are often labeled
-as “tape images”.
+as &ldquo;tape images&rdquo;.
 
 <P>When the emulation is running, the box also contains buttons which
-correspond to the <B>“Play”</B>, <B>“Record”</B> and <B>“Stop”</B> buttons
-of the tape drive, and additional <B>“Rewind”</B> and <B>“Forward”</B>
+correspond to the <B>&ldquo;Play&rdquo;</B>, <B>&ldquo;Record&rdquo;</B> and <B>&ldquo;Stop&rdquo;</B> buttons
+of the tape drive, and additional <B>&ldquo;Rewind&rdquo;</B> and <B>&ldquo;Forward&rdquo;</B>
 buttons which move the simulated tape to its start or end position,
-respectively. When the C64 asks you to “Press Record &amp; Play” it is
-sufficient to just click on the “Record” button. The “Auto-Start Drive 1”
-function automatically rewinds the tape and presses the “Play” button for
+respectively. When the C64 asks you to &ldquo;Press Record &amp; Play&rdquo; it is
+sufficient to just click on the &ldquo;Record&rdquo; button. The &ldquo;Auto-Start Drive 1&rdquo;
+function automatically rewinds the tape and presses the &ldquo;Play&rdquo; button for
 you, so you will rarely have to touch these controls.
 
 <P>There are some rare instances of software distributed on tape which
 refuses to run if it sees a disk drive connected. In this case, turn off the
-full 1541 emulation, and click “Eject” on all four disk drives.
+full 1541 emulation, and click &ldquo;Eject&rdquo; on all four disk drives.
 
 
 <H2>Video/Sound</H2>
 
-<P>With <B>“Display Type”</B> you can choose whether the emulation shall run
+<P>With <B>&ldquo;Display Type&rdquo;</B> you can choose whether the emulation shall run
 in a window or in full-screen mode. You can also switch between modes while
 Frodo is running by pressing the Enter key on the numeric keypad.
 
-<P><B>“Initial Window Size”</B> allows you to select the factor by which the
+<P><B>&ldquo;Initial Window Size&rdquo;</B> allows you to select the factor by which the
 emulation window is initially scaled up compared to the original C64 display
 resolution. The window can also be resized later while Frodo is running.
 
-<P>The <B>“Color Palette”</B> setting switches between two color schemes for
-the C64 display: The <EM>“Pepto”</EM> palette produces vibrant colors, while
-the <EM>“Colodore”</EM> palette is more desaturated but more closely
+<P>The <B>&ldquo;Color Palette&rdquo;</B> setting switches between two color schemes for
+the C64 display: The <EM>&ldquo;Pepto&rdquo;</EM> palette produces vibrant colors, while
+the <EM>&ldquo;Colodore&rdquo;</EM> palette is more desaturated but more closely
 matches what the original video display on a C64 looked like.
 
-<P><B>“Detect Sprite Collisions”</B> determines whether collisions between
+<P><B>&ldquo;Detect Sprite Collisions&rdquo;</B> determines whether collisions between
 sprites among themselves, and between sprites and background graphics should
 be detected by the C64. Turning off collisions may make you invincible in
 some older games (sadly, your enemies are likely to become invincible, too
@@ -121,104 +121,104 @@ some older games (sadly, your enemies are likely to become invincible, too
 <P>Frodo normally uses the lower border of the C64 display to overlay some
 information about the emulation speed (unless it is running at 100%) and a
 representation of the activity/error LEDs of the emulated disk drives. By
-deselecting <B>“Show Speed and Drive LED Status”</B> you can turn off this
+deselecting <B>&ldquo;Show Speed and Drive LED Status&rdquo;</B> you can turn off this
 display if you find that it distracts from the pure C64 experience.
 
-<P>The <B>“Sound Emulation”</B> selection controls the type of sound output.
-<EM>“None”</EM> means no sound, <EM>“Software”</EM> turns on the software
-sound emulation. Under Linux, there is another option, <EM>“Catweasel”</EM>
+<P>The <B>&ldquo;Sound Emulation&rdquo;</B> selection controls the type of sound output.
+<EM>&ldquo;None&rdquo;</EM> means no sound, <EM>&ldquo;Software&rdquo;</EM> turns on the software
+sound emulation. Under Linux, there is another option, <EM>&ldquo;Catweasel&rdquo;</EM>
 for using a hardware SID chip on a Catweasel MK3 board (you also need
 Catweasel kernel drivers for this).
 
-<P>The <EM>“Software”</EM> setting also gives you two choices for the kind
+<P>The <EM>&ldquo;Software&rdquo;</EM> setting also gives you two choices for the kind
 of C64 sound chip to emulate: The 6581 (recommended) is the original SID
 chip, while the 8580 is a newer revision with some audible differences. In
 Frodo, the setting affects the audio filters and the sound of combined
 waveforms. Some newer C64 software (1990s onwards) may only sound properly
-with the <EM>“8580”</EM> setting, some software also gives you a choice
-which SID chip to use. If in doubt, choose <EM>“6581”</EM>.
+with the <EM>&ldquo;8580&rdquo;</EM> setting, some software also gives you a choice
+which SID chip to use. If in doubt, choose <EM>&ldquo;6581&rdquo;</EM>.
 
 
 <H2>Input</H2>
 
-<P><B>“Joystick Port 1/2”</B> allows you to select which connected game
+<P><B>&ldquo;Joystick Port 1/2&rdquo;</B> allows you to select which connected game
 controller you want to use for each of the two C64 joystick ports. Note that
 most C64 games use a joystick in Port 2. If you don't want to use game
 controllers, Frodo also offers a <A HREF="keyboard.html">joystick
 emulation</A> on the numeric keypad.
 
 <P>Because C64 joysticks typically only have one fire button many games use
-the keyboard to control additional functions. With the “Button Mapping”
+the keyboard to control additional functions. With the &ldquo;Button Mapping&rdquo;
 feature you can map game controller buttons to C64 keys so you can play a
 game using only the controller, without having to reach for the keyboard.
-The <B>“Edit...”</B> button lets you define named button mappings which you
-can then select with the <B>“Button Mapping” chooser</B>. For example, the
-game “Turrican” normally uses the F7 key for throwing grenades and the SPACE
+The <B>&ldquo;Edit...&rdquo;</B> button lets you define named button mappings which you
+can then select with the <B>&ldquo;Button Mapping&rdquo; chooser</B>. For example, the
+game &ldquo;Turrican&rdquo; normally uses the F7 key for throwing grenades and the SPACE
 bar to activate the energy lines and the gyroscope. You can create a new
-button mapping named “Turrican” to assign these two keys to buttons on your
+button mapping named &ldquo;Turrican&rdquo; to assign these two keys to buttons on your
 controller which you find convenient.
 
 <P>The selected button mapping always applies to both controller ports. Note
-that the “A” (or Cross) button is always mapped to the joystick fire button,
+that the &ldquo;A&rdquo; (or Cross) button is always mapped to the joystick fire button,
 and the left and right trigger buttons control the rewind and
 fast-forwarding features of Frodo. These mappings cannot be changed. The
-“PLAY” key which you can map refers to the Play button on the “Datasette”
-tape drive. This mapping is intended for the game “Aquarius” which uses the
+&ldquo;PLAY&rdquo; key which you can map refers to the Play button on the &ldquo;Datasette&rdquo;
+tape drive. This mapping is intended for the game &ldquo;Aquarius&rdquo; which uses the
 Datasette as its controller.
 
-<P>With <B>“Swap Joysticks”</B> you can swap the assignments of the two
+<P>With <B>&ldquo;Swap Joysticks&rdquo;</B> you can swap the assignments of the two
 joystick ports without having to re-select the attached game controllers.
 If, for example, you only have one controller mapped to Port 2 but the
-game expects a joystick in port 1, then you can simply activate “Swap
-joysticks” and continue to use your already assigned controller.
+game expects a joystick in port 1, then you can simply activate &ldquo;Swap
+joysticks&rdquo; and continue to use your already assigned controller.
 
-<P>If the <B>“Twin-Stick Mode”</B> option is enabled, the right stick on
+<P>If the <B>&ldquo;Twin-Stick Mode&rdquo;</B> option is enabled, the right stick on
 each game controller controls the direction of the joystick on the opposite
-port. This is used to play games like “Robotron 2084”, which normally use
+port. This is used to play games like &ldquo;Robotron 2084&rdquo;, which normally use
 one joystick for movement and a second for firing, with only a single game
-controller. Use the “Swap Joysticks” option if the stick assignment is
+controller. Use the &ldquo;Swap Joysticks&rdquo; option if the stick assignment is
 wrong. Not recommended for two-player games.
 
-<P>The <B>“Enable Tape Motor Rumble”</B> option allows the C64 to control
+<P>The <B>&ldquo;Enable Tape Motor Rumble&rdquo;</B> option allows the C64 to control
 rumble effects on the attached game controllers via the tape drive motor
-signal. The game “Aquarius” uses this for providing haptic feedback. You
+signal. The game &ldquo;Aquarius&rdquo; uses this for providing haptic feedback. You
 should normally leave this option off.
 
 
 <H2>Options</H2>
 
-<P>When the field <B>“Limit Speed to 100%”</B> is active, Frodo caps the
+<P>When the field <B>&ldquo;Limit Speed to 100%&rdquo;</B> is active, Frodo caps the
 speed of the emulation at 100% of that of an original C64. This is usually
 what you want when playing games.
 
-<P>With the setting <B>“Fast Reset”</B> you can bypass the memory test which
+<P>With the setting <B>&ldquo;Fast Reset&rdquo;</B> you can bypass the memory test which
 the C64 normally performs on a reset, and which takes about three seconds to
 complete. Under emulation, this test is not necessary and resetting the C64
 (F12 key) gets much faster when it is bypassed.
 
-<P>The “Expansion Slot” group allows you to attach various devices to the
-expansion slot of the emulated C64. Under <B>“Memory Expansion”</B> you can
+<P>The &ldquo;Expansion Slot&rdquo; group allows you to attach various devices to the
+expansion slot of the emulated C64. Under <B>&ldquo;Memory Expansion&rdquo;</B> you can
 set the type and size of a RAM expansion module emulated by Frodo, or turn
-the emulation off (<EM>“None”</EM>). Very few C64 software actually uses a
+the emulation off (<EM>&ldquo;None&rdquo;</EM>). Very few C64 software actually uses a
 RAM expansion (operating systems like ACE and GEOS, some disk copy
-utilities, and the port of the “Sonic the Hedgehog” game, for example), so
-you can usually leave this at the <EM>“None”</EM> setting.
+utilities, and the port of the &ldquo;Sonic the Hedgehog&rdquo; game, for example), so
+you can usually leave this at the <EM>&ldquo;None&rdquo;</EM> setting.
 
-<P>If the “Memory Expansion” is set to <EM>“None”</EM>, you can use the
-<B>“Cartridge” file selection button</B> to choose a .crt cartridge image
+<P>If the &ldquo;Memory Expansion&rdquo; is set to <EM>&ldquo;None&rdquo;</EM>, you can use the
+<B>&ldquo;Cartridge&rdquo; file selection button</B> to choose a .crt cartridge image
 file to attach to the C64. At the moment, Frodo only supports regular ROM
 cartridges (that means no Ultimax, no Action Replay, no EasyFlash, nor any
 other funny things). When attaching a new cartridge, Frodo will reset the
 C64 to allow the cartridge software to start properly. Click on the
-<B>“Eject” button</B> to remove the cartridge from the emulated C64 and
+<B>&ldquo;Eject&rdquo; button</B> to remove the cartridge from the emulated C64 and
 return it to normal operation, ready to load disk-based games again.
 
 <P>Frodo comes with built-in standard C64 and 1541 drive firmware. If you
 want to use alternative firmware you can supply your own ROM files and use
-the functions of the “Firmware ROMs” group to define sets of firmware ROMs
-using the <B>“Edit...”</B> button, and then switch between them with the
-<B>“Firmware Set” chooser</B>. If, for example, you have JiffyDOS ROMs you
-can create a new firmware set called “JiffyDOS” and choose your JiffyDOS
+the functions of the &ldquo;Firmware ROMs&rdquo; group to define sets of firmware ROMs
+using the <B>&ldquo;Edit...&rdquo;</B> button, and then switch between them with the
+<B>&ldquo;Firmware Set&rdquo; chooser</B>. If, for example, you have JiffyDOS ROMs you
+can create a new firmware set called &ldquo;JiffyDOS&rdquo; and choose your JiffyDOS
 Kernal and Drive ROM files for this set, leaving the Basic and Char ROMs at
 the built-in defaults. When switching between firmware sets, Frodo will
 reset the C64 to allow the new firmware to start properly.
@@ -228,25 +228,25 @@ reset the C64 to allow the new firmware to start properly.
 
 <P>The settings in this group are only available in Frodo Lite.
 
-<P><B>“Cycles per line (CPU)”</B> and <B>“Cycles per Bad Line (CPU)”</B> set
+<P><B>&ldquo;Cycles per line (CPU)&rdquo;</B> and <B>&ldquo;Cycles per Bad Line (CPU)&rdquo;</B> set
 the number of clock cycles available to the C64 CPU per normal raster line
 and per Bad Line. If a program shows flickering lines or graphical flaws you
 can try to slightly alter both values.
 
-<P>With <B>“Cycles per line (CIA)”</B> you can control the speed of the CIA
+<P>With <B>&ldquo;Cycles per line (CIA)&rdquo;</B> you can control the speed of the CIA
 timers. Entering a higher value increases the frequency of cursor blinking
 and key repeat. Some programs don't run correcly with the default value.
 
-<P><B>“Cycles per line (1541)”</B> sets the number of cycles available to
+<P><B>&ldquo;Cycles per line (1541)&rdquo;</B> sets the number of cycles available to
 the 1541 processor emulation per raster line. There is normally no need to
 change this value. This setting has no effect if 1541 processor emulation is
 turned off.
 
-<P>The settings for the four “cycles” coming closest to an original PAL C64
+<P>The settings for the four &ldquo;cycles&rdquo; coming closest to an original PAL C64
 are (63, 23, 63, 64).
 
-<P>The setting <B>“Clear CIA ICR on write”</B> is necessary to make some
-programs (such as the games “Gyruss” and “Motos”) run that would otherwise
+<P>The setting <B>&ldquo;Clear CIA ICR on write&rdquo;</B> is necessary to make some
+programs (such as the games &ldquo;Gyruss&rdquo; and &ldquo;Motos&rdquo;) run that would otherwise
 hang in an endless interrupt loop because they use an unusual technique to
 acknowledge CIA interrupts (sometimes by accident, it appears...). It should
 normally be turned off.
@@ -254,33 +254,33 @@ normally be turned off.
 
 <H2>Menus and Other Buttons</H2>
 
-<P>Clicking <B>“Start”/“Continue”</B> or selecting the respective command
-from the “File” menu will close the settings window and start the actual
+<P>Clicking <B>&ldquo;Start&rdquo;/&ldquo;Continue&rdquo;</B> or selecting the respective command
+from the &ldquo;File&rdquo; menu will close the settings window and start the actual
 emulation or return to it. Likewise, <B>"Quit"</b> will discard your changes
 to the settings and quit Frodo.
 
-<P><B>“Auto-Start Drive 8 / 1”</B> starts the emulation and auto-runs the
+<P><B>&ldquo;Auto-Start Drive 8 / 1&rdquo;</B> starts the emulation and auto-runs the
 software from the image file mounted in disk drive 8 or tape drive 1 using
 standard load commands (to start from tape you have to eject the disk in
 drive 8). It behaves the same way as pressing Ctrl-F12 while the emulator is
 running.
 
-<P>With <B>“Create Disk Image File...”</B> in the “File” menu you can create
+<P>With <B>&ldquo;Create Disk Image File...&rdquo;</B> in the &ldquo;File&rdquo; menu you can create
 an empty .d64 image file if you need one, for example to save your progress
-in a game. Likewise, the <B>“Create Tape Image File...”</B> command creates
+in a game. Likewise, the <B>&ldquo;Create Tape Image File...&rdquo;</B> command creates
 a blank .tap image file for the tape drive. You can mount the created image
-files in the “Disk Drive Paths” and “Tape Drive Path” settings,
+files in the &ldquo;Disk Drive Paths&rdquo; and &ldquo;Tape Drive Path&rdquo; settings,
 respectively.
 
-<P>Once the emulation has been started you can use the <B>“Save
-snapshot...”</B> command in the “File” menu to save the current state of the
-emulated C64 to a file which you can then restore later using the <B>“Load
-Snapshot...”</B> command.
+<P>Once the emulation has been started you can use the <B>&ldquo;Save
+snapshot...&rdquo;</B> command in the &ldquo;File&rdquo; menu to save the current state of the
+emulated C64 to a file which you can then restore later using the <B>&ldquo;Load
+Snapshot...&rdquo;</B> command.
 
 <P><EM>Warning: The format of snapshot files is expected to change in future
 versions of Frodo, so don't get too attached to your saved snapshots.</EM>
 
-<P>The <B>“SAM Monitor...”</B> command in the “Tools” menu starts the <A
+<P>The <B>&ldquo;SAM Monitor...&rdquo;</B> command in the &ldquo;Tools&rdquo; menu starts the <A
 HREF="sam.html">SAM</A> machine language monitor which allows you to inspect
 the state of the running C64 program.
 

--- a/docs/technicalinfo.html
+++ b/docs/technicalinfo.html
@@ -7,16 +7,16 @@
 <H1>Technical Information</H1>
 
 <CITE>
-“Known?” said Gandalf.<BR>
-“I have known much that only the Wise know, Frodo.”
+&ldquo;Known?&rdquo; said Gandalf.<BR>
+&ldquo;I have known much that only the Wise know, Frodo.&rdquo;
 </CITE>
 
 <HR>
 
 <P>Frodo tries to exactly imitate C64 hardware features. Now the 64's
-hardware, especially its graphics chip “VIC-II” has a rather simple design
-resulting in many of the internal processes being exposed to the “outside”.
-So there are lots of “undocumented features” you can do effects with the
+hardware, especially its graphics chip &ldquo;VIC-II&rdquo; has a rather simple design
+resulting in many of the internal processes being exposed to the &ldquo;outside&rdquo;.
+So there are lots of &ldquo;undocumented features&rdquo; you can do effects with the
 designers never dared to dream about.
 
 <P>Frodo Lite uses a line-by-line emulation, meaning that the function of
@@ -49,7 +49,7 @@ raster line, such as special FLI routines, opening the left/right border,
 linecrunch, VSP, repeated sprite lines, and executing programs in open
 address spaces ($de00-$dfff) and in the color RAM. The 6510 emulation is
 also more precise and does the same memory accesses as the real 6510, even
-the “unnecessary” ones that result from the internal design of the 6510 and
+the &ldquo;unnecessary&rdquo; ones that result from the internal design of the 6510 and
 are not needed for the function of single opcodes (for example, in an
 instruction sequence like INX:INX:INX:INX, the 6510 reads every opcode
 twice).


### PR DESCRIPTION
The doc pages embed characters that are encoded with what looks like the notorious ` â€œ` rather than actual HTML entities. Doing so causes them to display incorrectly, at least with Safari and probably several other non-Microsoft browsers that don't special-case this quirk.