### PR TITLE
for autoconf set "HAVE_GTK=no" on gtk prereq. fail & update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prerequisites:
 
 * A C++20 compiler
 * SDL (Simple DirectMedia Layer) 2.x
-* GTK 3
+* GTK 3 [optional]
 
 Frodo can be compiled and installed in the usual way:
 

--- a/configure.ac
+++ b/configure.ac
@@ -15,8 +15,7 @@ AM_PATH_SDL2(2.30.0, AC_DEFINE(HAVE_SDL, 1, [SDL support is enabled]), AC_MSG_ER
 CPPFLAGS="$CPPFLAGS $SDL_CFLAGS"
 LIBS="$LIBS $SDL_LIBS"
 
-HAVE_GTK=no
-PKG_CHECK_MODULES(GTK, [gtk+-3.0 >= 3.24], HAVE_GTK=yes)
+PKG_CHECK_MODULES(GTK, [gtk+-3.0 >= 3.24], HAVE_GTK=yes, HAVE_GTK=no)
 if [[ $HAVE_GTK = yes ]]; then
   AC_DEFINE(HAVE_GTK, 1, [GTK preferences GUI is enabled])
   CPPFLAGS="$CPPFLAGS $GTK_CFLAGS"


### PR DESCRIPTION
via pkg.m4 from `pkg-config` it will always output AC_MSG_ERROR if prerequired module is missing in PKG_CHECK_MODULES, instead set "HAVE_GTK=no" on action if not found, so it will allow for correct configuration even then. 
Moreover hint that there is possibility to build without GTK (only learned that throught prv PR).